### PR TITLE
Update handshake_server.go

### DIFF
--- a/tlcp/handshake_server.go
+++ b/tlcp/handshake_server.go
@@ -789,8 +789,8 @@ func clientHelloInfo(ctx context.Context, c *Conn, clientHello *clientHelloMsg) 
 func (c *Conn) tlcpRand() ([]byte, error) {
 	rd := make([]byte, 32)
 	_, err := io.ReadFull(c.config.rand(), rd)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		return rd, err
 	}
 	var unixTime int64
 	if c.config.Time != nil {


### PR DESCRIPTION
bug fix: tlcpRand 函数如果成功从配置的 rand 设备读取到数据，直接返回。