### PR TITLE
修复GetConfigForClient中serverName丢失的问题

### DIFF
--- a/tlcp/handshake_server.go
+++ b/tlcp/handshake_server.go
@@ -775,7 +775,7 @@ func clientHelloInfo(ctx context.Context, c *Conn, clientHello *clientHelloMsg) 
 	supportedVers := supportedVersionsFromMax(clientHello.vers)
 	return &ClientHelloInfo{
 		CipherSuites:         clientHello.cipherSuites,
-		ServerName:           c.serverName,
+		ServerName:           clientHello.serverName,
 		SupportedVersions:    supportedVers,
 		TrustedCAIndications: clientHello.trustedAuthorities,
 		Conn:                 c.conn,


### PR DESCRIPTION
在比如SNI等使用场景中发现serverName丢失，发现是传给GetConfigForClient函数的config没有正确拷贝。